### PR TITLE
database seeder deletes and seeds all tables

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,7 +14,15 @@ class DatabaseSeeder extends Seeder
     {
         Model::unguard();
 
-        $this->call(UserTableSeeder::class);
+        DB::table('charities')->delete();
+        DB::table('users')->delete();
+        DB::table('games')->delete();
+        DB::table('selections')->delete();
+
+        $this->call('CharitiesSeeder');
+        $this->call('UsersSeeder');
+        $this->call('GamesSeeder');
+        $this->call('SelectionsSeeder');
 
         Model::reguard();
     }


### PR DESCRIPTION
we can now use `php artisan migrate:refresh --seed` so we don't have to seed each table individually